### PR TITLE
Fix example app

### DIFF
--- a/ClueExampleApp/ViewController.m
+++ b/ClueExampleApp/ViewController.m
@@ -17,7 +17,6 @@
 
 // Handle shake gesture to start/stop recording
 - (void)motionBegan:(UIEventSubtype)motion withEvent:(UIEvent *)event {
-    [ClueController sharedInstance] 
     [[ClueController sharedInstance] handleShake:motion];
 }
 


### PR DESCRIPTION
Remove standalone call to `[ClueController sharedInstance] ` that generates a compiler error.