### PR TITLE
Fix MFMailComposeViewController not being dismissed

### DIFF
--- a/Clue/Classes/ModulesUtils/CLUMailDelegate.m
+++ b/Clue/Classes/ModulesUtils/CLUMailDelegate.m
@@ -26,6 +26,8 @@
         case MFMailComposeResultFailed:
             break;
     }
+
+    [controller dismissViewControllerAnimated:YES completion:nil];
 }
 
 @end


### PR DESCRIPTION
Dismiss mailComposeController after user sent, saved, or canceled the mail.